### PR TITLE
Fixed issue: Persisted edge host value was not used for Target request issued upon app close & relaunch

### DIFF
--- a/AEPTarget/Sources/Target+PublicAPI.swift
+++ b/AEPTarget/Sources/Target+PublicAPI.swift
@@ -185,10 +185,10 @@ import Foundation
     /// Sets the Target session identifier.
     ///
     /// The provided session Id is persisted in the SDK for a period defined by `target.sessionTimeout` configuration setting.
-    /// If the provided sessionId is nil or empty or if the privacy status is opted out, the SDK will remove the session Id value from persistence.
+    /// If the provided sessionId is nil or empty or if the privacy status is opted out, the SDK will remove the session Id value from the persistence.
     ///
-    /// This ID is preserved between app upgrades, is saved and restored during the standard application
-    /// backup process, and is removed at uninstall, upon privacy status update to opt out or when AEPTarget.resetExperience is called.
+    /// This ID is preserved between app upgrades, is saved and restored during the standard application backup process,
+    /// and is removed at uninstall, upon privacy status update to opted out or when the AEPTarget.resetExperience API is called.
     ///
     /// - Parameter id: a string containing the value of the Target session Id to be set in the SDK.
     static func setSessionId(_ id: String?) {
@@ -200,9 +200,9 @@ import Foundation
     /// Gets the Target session identifier.
     ///
     /// The session Id is generated locally in the SDK upon initial Target request and persisted for a period defined by `target.sessionTimeout` configuration setting.
-    /// If the session timeout happens upon a subsequent Target request, a new sessionId will be generated for use in the request and persisted in the SDK.
+    /// If the session timeout happens upon a subsequent Target request, a new session Id will be generated for use in the request and persisted in the SDK.
     ///
-    /// - Parameter completion: the callback `closure` invoked with the current session Id or `nil` if there was an error retrieving it.
+    /// - Parameter completion: the callback `closure` invoked with the current session Id, or `nil` if there was an error retrieving it.
     static func getSessionId(_ completion: @escaping (String?, Error?) -> Void) {
         let event = Event(name: TargetConstants.EventName.GET_SESSION_ID, type: EventType.target, source: EventSource.requestIdentity, data: nil)
         MobileCore.dispatch(event: event) { responseEvent in
@@ -230,15 +230,15 @@ import Foundation
 
     /// Sets the Target user identifier.
     ///
-    /// The provided Tnt Id is persisted in the SDK and attached to subsequent Target requests. It is used to
+    /// The provided tnt Id is persisted in the SDK and attached to subsequent Target requests. It is used to
     /// derive the edge host value in the SDK, which is also persisted and used in future Target requests.
     ///
-    /// If the provided Tnt Id is nil or empty or if the privacy status is opted out, the SDK will remove the Tnt Id and edge host values from persistence.
+    /// If the provided tnt Id is nil or empty or if the privacy status is opted out, the SDK will remove the tnt Id and edge host values from the persistence.
     ///
     /// This ID is preserved between app upgrades, is saved and restored during the standard application backup process,
-    /// and is removed at uninstall, upon privacy status update to opt out or when AEPTarget.resetExperience is called.
+    /// and is removed at uninstall, upon privacy status update to opted out or when the AEPTarget.resetExperience API is called.
     ///
-    /// - Parameter id: a string containing the value of the Tnt Id to be set in the SDK.
+    /// - Parameter id: a string containing the value of the tnt Id to be set in the SDK.
     static func setTntId(_ id: String?) {
         let eventData = [TargetConstants.EventDataKeys.TNT_ID: id ?? ""]
         let event = Event(name: TargetConstants.EventName.SET_TNT_ID, type: EventType.target, source: EventSource.requestIdentity, data: eventData)
@@ -247,18 +247,15 @@ import Foundation
 
     /// Gets the Target user identifier.
     ///
-    /// The tntId is returned in the network response from Target after a successful call to `prefetchContent` API or `retrieveLocationContent` API, which is then persisted in the SDK.
-    /// The persisted tntId is used in subsequent Target requests until a different tntId is returned from Target or a new tntId is set using `setTntId` API.
+    /// The tnt Id is returned in the network response from Target after a successful call to `prefetchContent` API or `retrieveLocationContent` API, which is then persisted in the SDK.
+    /// The persisted tnt Id is used in subsequent Target requests until a different tnt Id is returned from Target, or a new tnt Id is set using `setTntId` API.
     ///
-    /// This ID is preserved between app upgrades, is saved and restored during the standard application
-    /// backup process, and is removed at uninstall or when AEPTarget.resetExperience is called.
-    ///
-    /// - Parameter completion:  the callback `closure` invoked with the current tnt id or `nil` if no tnt id is set.
+    /// - Parameter completion:  the callback `closure` invoked with the current tnt Id, or `nil` if there was an error retrieving it.
     static func getTntId(_ completion: @escaping (String?, Error?) -> Void) {
         let event = Event(name: TargetConstants.EventName.GET_TNT_ID, type: EventType.target, source: EventSource.requestIdentity, data: nil)
         MobileCore.dispatch(event: event) { responseEvent in
             guard let responseEvent = responseEvent else {
-                let error = "Request to get third party id failed, \(TargetError.ERROR_TIMEOUT)"
+                let error = "Request to get tnt Id failed, \(TargetError.ERROR_TIMEOUT)"
                 completion(nil, TargetError(message: error))
                 Log.warning(label: Target.LOG_TAG, error)
                 return
@@ -270,7 +267,7 @@ import Foundation
                 return
             }
             guard let tntId = eventData[TargetConstants.EventDataKeys.TNT_ID] as? String else {
-                let error = "Unable to handle response, No tntid available."
+                let error = "Unable to handle response, tnt Id is not available."
                 completion(nil, TargetError(message: error))
                 Log.warning(label: Target.LOG_TAG, error)
                 return

--- a/AEPTarget/Sources/TargetState.swift
+++ b/AEPTarget/Sources/TargetState.swift
@@ -123,7 +123,7 @@ class TargetState {
         }
         if
             let newClientCode = configuration[TargetConstants.Configuration.SharedState.Keys.TARGET_CLIENT_CODE] as? String,
-            newClientCode != clientCode
+            storedConfigurationSharedState != nil, newClientCode != clientCode
         {
             updateEdgeHost(nil)
         }

--- a/AEPTarget/Tests/FunctionalTests/TargetFunctionalTests.swift
+++ b/AEPTarget/Tests/FunctionalTests/TargetFunctionalTests.swift
@@ -262,8 +262,6 @@ class TargetFunctionalTests: TargetFunctionalTestsBase {
         target = Target(runtime: mockRuntime)
         target.onRegistered()
         XCTAssertEqual("935CDD24-8FD7-4B30-8508-4BE40C3FC263", target.targetState.storedSessionId)
-        let sessionId = target.targetState.sessionId
-        XCTAssertNotEqual("935CDD24-8FD7-4B30-8508-4BE40C3FC263", sessionId)
         XCTAssertEqual("mboxedge35.tt.omtrdc.net", target.targetState.storedEdgeHost)
         let prefetchDataArray: [[String: Any]?] = [
             TargetPrefetch(name: "Drink_1"),
@@ -281,7 +279,7 @@ class TargetFunctionalTests: TargetFunctionalTestsBase {
         mockNetworkService.mock { request in
             XCTAssertNotNil(request)
             let queryMap = self.getQueryMap(url: request.url.absoluteString)
-            XCTAssertEqual(queryMap["sessionId"] ?? "", sessionId)
+            XCTAssertNotEqual(queryMap["sessionId"] ?? "", "935CDD24-8FD7-4B30-8508-4BE40C3FC263")
             XCTAssertFalse(request.url.absoluteString.contains("mboxedge35.tt.omtrdc.net"))
             return nil
         }

--- a/AEPTargetDemoApp/ContentView.swift
+++ b/AEPTargetDemoApp/ContentView.swift
@@ -19,7 +19,7 @@ struct ContentView: View {
     @State var thirdPartyId: String = ""
     @State var updatedThirdPartyId: String = ""
     @State var sessionId: String = ""
-    @State var updatedsessionId: String = ""
+    @State var updatedSessionId: String = ""
     @State var tntId: String = ""
     @State var updatedTntId: String = ""
     @State var griffonUrl: String = TestConstants.GRIFFON_URL
@@ -64,7 +64,7 @@ struct ContentView: View {
                         getSessionId()
                     }.padding(10)
 
-                    TextField("Please enter Session Id", text: $updatedsessionId).multilineTextAlignment(.center)
+                    TextField("Please enter Session Id", text: $updatedSessionId).multilineTextAlignment(.center)
                     Button("Set Session Id") {
                         setSessionId()
                     }.padding(10)
@@ -194,7 +194,7 @@ struct ContentView: View {
     }
     
     func setSessionId() {
-        Target.setSessionId(updatedsessionId)
+        Target.setSessionId(updatedSessionId)
     }
     
     func getThirdPartyId() {

--- a/Documentation/AEPTarget.md
+++ b/Documentation/AEPTarget.md
@@ -424,9 +424,9 @@ Target.getThirdPartyId({id, err in
 
 This API sets the Target user identifier.
 
-The provided Tnt Id is persisted in the SDK and attached to subsequent Target requests. It is used to derive the edge host value in the SDK, which is also persisted and used in future Target requests.
+The provided tnt Id is persisted in the SDK and attached to subsequent Target requests. It is used to derive the edge host value in the SDK, which is also persisted and used in future Target requests.
 
-If the provided Tnt Id is nil or empty or if the privacy status is opted out, the SDK will remove the Tnt Id and edge host values from persistence.
+If the provided tnt Id is nil or empty, or if the privacy status is opted out, the SDK will remove the tnt Id and edge host values from the persistence.
 
     This ID is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall, upon privacy status update to opted out, or when the resetExperience API is used.
 
@@ -466,7 +466,7 @@ Target.setTntId("f741a5d5-09c0-4931-bf53-b9e568c5f782.35_0")
 
 This API gets the Target user identifier. 
 
-The tntId is returned in the network response from Target after a successful call to `prefetchContent` API or `retrieveLocationContent` API, which is then persisted in the SDK. The persisted tntId is used in subsequent Target requests until a different tntId is returned from Target or a new tntId is set using `setTntId` API.
+The tnt Id is returned in the network response from Target after a successful call to `prefetchContent` API or `retrieveLocationContent` API, which is then persisted in the SDK. The persisted tnt Id is used in subsequent Target requests until a different tnt Id is returned from Target, or a new tnt Id is set using `setTntId` API.
 
 ### Swift 
 
@@ -476,7 +476,7 @@ The tntId is returned in the network response from Target after a successful cal
 static func getTntId(_ completion: @escaping (String?, Error?) -> Void)
 ```
 
-  - *completion* : invoked with the `tntId` value. If no Target Id was set or if there was an error retrieving it, this value will be `nil`.
+  - *completion* : invoked with the `tntId` value, or `nil` if there was an error retrieving it.
 
 #### Example
 
@@ -494,7 +494,7 @@ static func getTntId(_ completion: @escaping (String?, Error?) -> Void)
 + (void) getTntId: (void (^ _Nonnull) (NSString* _Nullable tntId, NSError* _Nullable error)) completion;
 ```
 
-  - *completion* : invoked with the `tntId` value. If no Target Id was set or if there was an error retrieving it, this value will be `nil`.
+  - *completion* : invoked with the `tntId` value, or `nil` if there was an error retrieving it.
 
 #### Example
 
@@ -508,7 +508,7 @@ static func getTntId(_ completion: @escaping (String?, Error?) -> Void)
 
 This API sets the Target session identifier.
 
-The provided session Id is persisted in the SDK for a period defined by `target.sessionTimeout` configuration setting. If the provided sessionId is nil or empty or if the privacy status is opted out, the SDK will remove the session Id value from persistence.
+The provided session Id is persisted in the SDK for a period defined by `target.sessionTimeout` configuration setting. If the provided sessionId is nil or empty, or if the privacy status is opted out, the SDK will remove the session Id value from the persistence.
 
     This ID is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall, upon privacy status update to opted out, or when the resetExperience API is used.
 
@@ -548,7 +548,7 @@ Target.setSessionId("5568c1a2-ece1-42d1-b807-930623998ec3")
 
 This API gets the Target session identifier. 
 
-The session Id is generated locally in the SDK upon initial Target request and persisted for a period defined by `target.sessionTimeout` configuration setting. If the session timeout happens upon a subsequent Target request, a new sessionId will be generated for use in the request and persisted in the SDK.
+The session Id is generated locally in the SDK upon initial Target request and persisted for a period defined by `target.sessionTimeout` configuration setting. If the session timeout happens upon a subsequent Target request, a new session Id will be generated for use in the request and persisted in the SDK.
 
 ### Swift 
 
@@ -558,7 +558,7 @@ The session Id is generated locally in the SDK upon initial Target request and p
 static func getSessionId(_ completion: @escaping (String?, Error?) -> Void)
 ```
 
-  - *completion* : invoked with the Target `sessionId` value or `nil` if there was an error retrieving it.
+  - *completion* : invoked with the Target `sessionId` value, or `nil` if there was an error retrieving it.
 
 #### Example
 
@@ -576,7 +576,7 @@ static func getSessionId(_ completion: @escaping (String?, Error?) -> Void)
 + (void) getSessionId: (void (^ _Nonnull) (NSString* _Nullable sessionId, NSError* _Nullable error)) completion;
 ```
 
-  - *completion* : invoked with the Target `sessionId` value or `nil` if there was an error retrieving it.
+  - *completion* : invoked with the Target `sessionId` value, or `nil` if there was an error retrieving it.
 
 #### Example
 

--- a/Documentation/AEPTarget.md
+++ b/Documentation/AEPTarget.md
@@ -508,7 +508,7 @@ static func getTntId(_ completion: @escaping (String?, Error?) -> Void)
 
 This API sets the Target session identifier.
 
-The provided session Id is persisted in the SDK for a period defined by `target.sessionTimeout` configuration setting. If the provided sessionId is nil or empty, or if the privacy status is opted out, the SDK will remove the session Id value from the persistence.
+The provided session Id is persisted in the SDK for a period defined by `target.sessionTimeout` configuration setting. If the provided session Id is nil or empty, or if the privacy status is opted out, the SDK will remove the session Id value from the persistence.
 
     This ID is preserved between app upgrades, is saved and restored during the standard application backup process, and is removed at uninstall, upon privacy status update to opted out, or when the resetExperience API is used.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Ref: [MOB-17008]

- Previously persisted edge host should be used when a Target request is issued on app relaunch.
- Fixed an incorrect test case
- code cleanup

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
