### PR TITLE
Support remote updates to Target property token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
 
   build-and-test:
     macos:
-      xcode: 12.0.1 # Specify the Xcode version to use
+      xcode: 13.0.0 # Specify the Xcode version to use
 
     steps:
       - checkout

--- a/AEPTarget/Sources/Event+Target.swift
+++ b/AEPTarget/Sources/Event+Target.swift
@@ -16,51 +16,51 @@ import Foundation
 extension Event {
     /// Reads an array`TargetPrefetch` from the event data
     var prefetchObjectArray: [TargetPrefetch]? {
-        return TargetPrefetch.from(dictionaries: data?[TargetConstants.EventDataKeys.PREFETCH_REQUESTS] as? [[String: Any]])
+        TargetPrefetch.from(dictionaries: data?[TargetConstants.EventDataKeys.PREFETCH_REQUESTS] as? [[String: Any]])
     }
 
     /// Reads the `TargetParameters` from the event data
     var targetParameters: TargetParameters? {
-        return TargetParameters.from(dictionary: data?[TargetConstants.EventDataKeys.TARGET_PARAMETERS] as? [String: Any])
+        TargetParameters.from(dictionary: data?[TargetConstants.EventDataKeys.TARGET_PARAMETERS] as? [String: Any])
     }
 
     /// Reads the Target `at_property` from the event data
     var propertyToken: String {
-        return data?[TargetConstants.EventDataKeys.AT_PROPERTY] as? String ?? ""
+        data?[TargetConstants.EventDataKeys.AT_PROPERTY] as? String ?? ""
     }
 
     /// Returns true if this event is a prefetch request event
     var isPrefetchEvent: Bool {
-        return data?[TargetConstants.EventDataKeys.PREFETCH_REQUESTS] != nil
+        data?[TargetConstants.EventDataKeys.PREFETCH_REQUESTS] != nil
     }
 
     /// Returns true if this event is a load request event
     var isLoadRequest: Bool {
-        return data?[TargetConstants.EventDataKeys.LOAD_REQUESTS] != nil
+        data?[TargetConstants.EventDataKeys.LOAD_REQUESTS] != nil
     }
 
     /// Reads an array`TargetRequest` from the event data
     var targetRequests: [TargetRequest]? {
-        return TargetRequest.from(dictionaries: data?[TargetConstants.EventDataKeys.LOAD_REQUESTS] as? [[String: Any]])
+        TargetRequest.from(dictionaries: data?[TargetConstants.EventDataKeys.LOAD_REQUESTS] as? [[String: Any]])
     }
 
     /// Returns true if the event is location display request event
     var isLocationsDisplayedEvent: Bool {
-        return data?[TargetConstants.EventDataKeys.IS_LOCATION_DISPLAYED] as? Bool ?? false
+        data?[TargetConstants.EventDataKeys.IS_LOCATION_DISPLAYED] as? Bool ?? false
     }
 
     /// Returns true if the event is location clicked request event
     var isLocationClickedEvent: Bool {
-        return data?[TargetConstants.EventDataKeys.IS_LOCATION_CLICKED] as? Bool ?? false
+        data?[TargetConstants.EventDataKeys.IS_LOCATION_CLICKED] as? Bool ?? false
     }
 
     /// Returns true if this event is a reset experience request event
     var isResetExperienceEvent: Bool {
-        return data?[TargetConstants.EventDataKeys.RESET_EXPERIENCE] as? Bool ?? false
+        data?[TargetConstants.EventDataKeys.RESET_EXPERIENCE] as? Bool ?? false
     }
 
     /// Returns true if this event is a clear prefetch request event
     var isClearPrefetchCache: Bool {
-        return data?[TargetConstants.EventDataKeys.CLEAR_PREFETCH_CACHE] as? Bool ?? false
+        data?[TargetConstants.EventDataKeys.CLEAR_PREFETCH_CACHE] as? Bool ?? false
     }
 }

--- a/AEPTarget/Sources/Event+Target.swift
+++ b/AEPTarget/Sources/Event+Target.swift
@@ -24,6 +24,11 @@ extension Event {
         return TargetParameters.from(dictionary: data?[TargetConstants.EventDataKeys.TARGET_PARAMETERS] as? [String: Any])
     }
 
+    /// Reads the Target `at_property` from the event data
+    var propertyToken: String {
+        return data?[TargetConstants.EventDataKeys.AT_PROPERTY] as? String ?? ""
+    }
+
     /// Returns true if this event is a prefetch request event
     var isPrefetchEvent: Bool {
         return data?[TargetConstants.EventDataKeys.PREFETCH_REQUESTS] != nil

--- a/AEPTarget/Sources/Target.swift
+++ b/AEPTarget/Sources/Target.swift
@@ -643,7 +643,7 @@ public class Target: NSObject, Extension {
         return lifecycleContextData
     }
 
-    private func sendTargetRequest(_: Event,
+    private func sendTargetRequest(_ event: Event,
                                    batchRequests: [TargetRequest]? = nil,
                                    prefetchRequests: [TargetPrefetch]? = nil,
                                    targetParameters: TargetParameters? = nil,
@@ -655,9 +655,11 @@ public class Target: NSObject, Extension {
         let thirdPartyId = targetState.thirdPartyId
         let environmentId = Int64(targetState.environmentId)
         let lifecycleContextData = getLifecycleDataForTarget(lifecycleData: lifecycleData)
-        let propToken = targetState.propertyToken
 
-        guard let requestJson = TargetDeliveryRequestBuilder.build(tntId: tntId, thirdPartyId: thirdPartyId, identitySharedState: identityData, lifecycleSharedState: lifecycleContextData, targetPrefetchArray: prefetchRequests, targetRequestArray: batchRequests, targetParameters: targetParameters, notifications: targetState.notifications.isEmpty ? nil : targetState.notifications, environmentId: environmentId, propertyToken: propToken, qaModeParameters: previewManager.previewParameters)?.toJSON() else {
+        // Give preference to property token passed in configuration over event data "at_property".
+        let propertyToken = !targetState.propertyToken.isEmpty ? targetState.propertyToken : event.propertyToken
+
+        guard let requestJson = TargetDeliveryRequestBuilder.build(tntId: tntId, thirdPartyId: thirdPartyId, identitySharedState: identityData, lifecycleSharedState: lifecycleContextData, targetPrefetchArray: prefetchRequests, targetRequestArray: batchRequests, targetParameters: targetParameters, notifications: targetState.notifications.isEmpty ? nil : targetState.notifications, environmentId: environmentId, propertyToken: propertyToken, qaModeParameters: previewManager.previewParameters)?.toJSON() else {
             return "Failed to generate request parameter(JSON) for target delivery API call"
         }
 

--- a/AEPTarget/Sources/TargetConstants.swift
+++ b/AEPTarget/Sources/TargetConstants.swift
@@ -198,6 +198,7 @@ enum TargetConstants {
         static let ORDER_PARAMETERS = "orderparameters"
         static let PRODUCT_PARAMETERS = "productparameters"
         static let PROFILE_PARAMETERS = "profileparameters"
+        static let AT_PROPERTY = "at_property"
         static let TARGET_CONTENT = "content"
         static let TARGET_DATA_PAYLOAD = "data"
         static let TARGET_RESPONSE_PAIR_ID = "responsePairId"

--- a/AEPTarget/Tests/FunctionalTests/TargetDisplayedLocationsFunctionalTests.swift
+++ b/AEPTarget/Tests/FunctionalTests/TargetDisplayedLocationsFunctionalTests.swift
@@ -74,6 +74,7 @@ class TargetDisplayedLocationsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "notifications",
                 "environmentId",
             ]))
@@ -107,6 +108,13 @@ class TargetDisplayedLocationsFunctionalTests: TargetFunctionalTestsBase {
                 "timeOffsetInMinutes",
             ]))
 
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("67444eb4-3681-40b4-831d-e082f5ccddcd", propertyDictionary["token"] as? String)
+            
             // verifies payloadDictionary["notifications"]
             guard let notificationsArray = payloadDictionary["notifications"] as? [Any?] else {
                 XCTFail()
@@ -126,6 +134,276 @@ class TargetDisplayedLocationsFunctionalTests: TargetFunctionalTestsBase {
             XCTAssertTrue(notificationsJson.contains("\"a.DeviceName\""))
             XCTAssertTrue(notificationsJson.contains("\"a.AppID\""))
             XCTAssertTrue(notificationsJson.contains("\"a.locale\""))
+
+            let validResponse = HTTPURLResponse(url: URL(string: "https://acopprod3.tt.omtrdc.net/rest/v1/delivery")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
+        }
+        guard let eventListener: EventListener = mockRuntime.listeners["com.adobe.eventType.target-com.adobe.eventSource.requestContent"] else {
+            XCTFail()
+            return
+        }
+        XCTAssertTrue(target.readyForEvent(locationDisplayedEvent))
+        // handles the location display event
+        eventListener(locationDisplayedEvent)
+
+        // Check the notifications are cleared
+        XCTAssertTrue(target.targetState.notifications.isEmpty)
+
+        // verifies the content of network response was stored correctly
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", target.targetState.tntId)
+        XCTAssertEqual("mboxedge35.tt.omtrdc.net", target.targetState.edgeHost)
+
+        // verifies the Target's shared state
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", mockRuntime.createdSharedStates[0]?["tntid"] as? String)
+    }
+    
+    func testLocationDisplayed_withPropertyTokenInConfigurationAndEventData() {
+        // mocked network response
+        let responseString = """
+            {
+              "status": 200,
+              "id": {
+                "tntId": "DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0",
+                "marketingCloudVisitorId": "38209274908399841237725561727471528301"
+              },
+              "requestId": "01d4a408-6978-48f7-95c6-03f04160b257",
+              "client": "acopprod3",
+              "edgeHost": "mboxedge35.tt.omtrdc.net",
+              "notifications": {
+                    "id": "4BA0B2EF-9A20-4BDC-9F97-0B955BC5FF84",
+              }
+            }
+        """
+
+        // Build the location data
+        let data: [String: Any] = [
+            "names": mockMBox,
+            "targetparams": TargetParameters(profileParameters: mockProfileParam).asDictionary() as Any,
+            "at_property": "a2ec61d0-fab8-42f9-bf0f-699d169b48d8",
+            "islocationdisplayed": true,
+        ]
+        let locationDisplayedEvent = Event(name: "TargetLocationsDisplayed", type: "com.adobe.eventType.target", source: "com.adobe.eventSource.requestContent", data: data)
+
+        // creates a configuration's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.configuration", event: locationDisplayedEvent, data: (value: mockConfigSharedState, status: .set))
+
+        // creates an identity's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.identity", event: locationDisplayedEvent, data: (value: mockIdentityData, status: .set))
+
+        // target state has mock prefetch mboxes
+        target.targetState.mergePrefetchedMboxJson(mboxesDictionary: mockMBoxJson)
+
+        // registers the event listeners for Target extension
+        target.onRegistered()
+
+        // override network service
+        let mockNetworkService = TestableNetworkService()
+        ServiceProvider.shared.networkService = mockNetworkService
+        mockNetworkService.mock { request in
+            // verifies network request
+            XCTAssertNotNil(request)
+            guard let payloadDictionary = self.payloadAsDictionary(request.connectPayload) else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId="))
+            XCTAssertTrue(Set(payloadDictionary.keys) == Set([
+                "id",
+                "experienceCloud",
+                "context",
+                "property",
+                "notifications",
+                "environmentId",
+            ]))
+
+            // verifies payloadDictionary["id"]
+            guard let idDictionary = payloadDictionary["id"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("38209274908399841237725561727471528301", idDictionary["marketingCloudVisitorId"] as? String)
+            guard let vids = idDictionary["customerIds"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, vids.count)
+            XCTAssertEqual("unknown", vids[0]["authenticatedState"] as? String)
+            XCTAssertEqual("vid_id_1", vids[0]["id"] as? String)
+            XCTAssertEqual("vid_type_1", vids[0]["integrationCode"] as? String)
+
+            // verifies payloadDictionary["context"]
+            guard let context = payloadDictionary["context"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(Set(context.keys) == Set([
+                "userAgent",
+                "mobilePlatform",
+                "screen",
+                "channel",
+                "application",
+                "timeOffsetInMinutes",
+            ]))
+
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("67444eb4-3681-40b4-831d-e082f5ccddcd", propertyDictionary["token"] as? String)
+            
+            // verifies payloadDictionary["notifications"]
+            guard let notificationsArray = payloadDictionary["notifications"] as? [Any?] else {
+                XCTFail()
+                return nil
+            }
+
+            XCTAssertNotNil(notificationsArray)
+            XCTAssertTrue(notificationsArray.capacity == 2)
+
+            let notificationsJson = self.prettify(notificationsArray)
+            XCTAssertTrue(notificationsJson.contains("\"sometoken\""))
+            XCTAssertTrue(notificationsJson.contains("\"sometoken2\""))
+            XCTAssertTrue(notificationsJson.contains("\"type\" : \"display\""))
+            XCTAssertTrue(notificationsJson.contains("\"name\" : \"mbox1\""))
+            XCTAssertTrue(notificationsJson.contains("\"name\" : \"mbox2\""))
+
+            let validResponse = HTTPURLResponse(url: URL(string: "https://acopprod3.tt.omtrdc.net/rest/v1/delivery")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
+        }
+        guard let eventListener: EventListener = mockRuntime.listeners["com.adobe.eventType.target-com.adobe.eventSource.requestContent"] else {
+            XCTFail()
+            return
+        }
+        XCTAssertTrue(target.readyForEvent(locationDisplayedEvent))
+        // handles the location display event
+        eventListener(locationDisplayedEvent)
+
+        // Check the notifications are cleared
+        XCTAssertTrue(target.targetState.notifications.isEmpty)
+
+        // verifies the content of network response was stored correctly
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", target.targetState.tntId)
+        XCTAssertEqual("mboxedge35.tt.omtrdc.net", target.targetState.edgeHost)
+
+        // verifies the Target's shared state
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", mockRuntime.createdSharedStates[0]?["tntid"] as? String)
+    }
+    
+    func testLocationDisplayed_withPropertyTokenInEventData() {
+        mockConfigSharedState = ["target.clientCode": "acopprod3", "global.privacy": "optedin"]
+        
+        // mocked network response
+        let responseString = """
+            {
+              "status": 200,
+              "id": {
+                "tntId": "DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0",
+                "marketingCloudVisitorId": "38209274908399841237725561727471528301"
+              },
+              "requestId": "01d4a408-6978-48f7-95c6-03f04160b257",
+              "client": "acopprod3",
+              "edgeHost": "mboxedge35.tt.omtrdc.net",
+              "notifications": {
+                    "id": "4BA0B2EF-9A20-4BDC-9F97-0B955BC5FF84",
+              }
+            }
+        """
+
+        // Build the location data
+        let data: [String: Any] = [
+            "names": mockMBox,
+            "targetparams": TargetParameters(profileParameters: mockProfileParam).asDictionary() as Any,
+            "at_property": "a2ec61d0-fab8-42f9-bf0f-699d169b48d8",
+            "islocationdisplayed": true,
+        ]
+        let locationDisplayedEvent = Event(name: "TargetLocationsDisplayed", type: "com.adobe.eventType.target", source: "com.adobe.eventSource.requestContent", data: data)
+
+        // creates a configuration's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.configuration", event: locationDisplayedEvent, data: (value: mockConfigSharedState, status: .set))
+
+        // creates an identity's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.identity", event: locationDisplayedEvent, data: (value: mockIdentityData, status: .set))
+
+        // target state has mock prefetch mboxes
+        target.targetState.mergePrefetchedMboxJson(mboxesDictionary: mockMBoxJson)
+
+        // registers the event listeners for Target extension
+        target.onRegistered()
+
+        // override network service
+        let mockNetworkService = TestableNetworkService()
+        ServiceProvider.shared.networkService = mockNetworkService
+        mockNetworkService.mock { request in
+            // verifies network request
+            XCTAssertNotNil(request)
+            guard let payloadDictionary = self.payloadAsDictionary(request.connectPayload) else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId="))
+            XCTAssertTrue(Set(payloadDictionary.keys) == Set([
+                "id",
+                "experienceCloud",
+                "context",
+                "property",
+                "notifications",
+                "environmentId",
+            ]))
+
+            // verifies payloadDictionary["id"]
+            guard let idDictionary = payloadDictionary["id"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("38209274908399841237725561727471528301", idDictionary["marketingCloudVisitorId"] as? String)
+            guard let vids = idDictionary["customerIds"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, vids.count)
+            XCTAssertEqual("unknown", vids[0]["authenticatedState"] as? String)
+            XCTAssertEqual("vid_id_1", vids[0]["id"] as? String)
+            XCTAssertEqual("vid_type_1", vids[0]["integrationCode"] as? String)
+
+            // verifies payloadDictionary["context"]
+            guard let context = payloadDictionary["context"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(Set(context.keys) == Set([
+                "userAgent",
+                "mobilePlatform",
+                "screen",
+                "channel",
+                "application",
+                "timeOffsetInMinutes",
+            ]))
+
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("a2ec61d0-fab8-42f9-bf0f-699d169b48d8", propertyDictionary["token"] as? String)
+            
+            // verifies payloadDictionary["notifications"]
+            guard let notificationsArray = payloadDictionary["notifications"] as? [Any?] else {
+                XCTFail()
+                return nil
+            }
+
+            XCTAssertNotNil(notificationsArray)
+            XCTAssertTrue(notificationsArray.capacity == 2)
+
+            let notificationsJson = self.prettify(notificationsArray)
+            XCTAssertTrue(notificationsJson.contains("\"sometoken\""))
+            XCTAssertTrue(notificationsJson.contains("\"sometoken2\""))
+            XCTAssertTrue(notificationsJson.contains("\"type\" : \"display\""))
+            XCTAssertTrue(notificationsJson.contains("\"name\" : \"mbox1\""))
+            XCTAssertTrue(notificationsJson.contains("\"name\" : \"mbox2\""))
 
             let validResponse = HTTPURLResponse(url: URL(string: "https://acopprod3.tt.omtrdc.net/rest/v1/delivery")!, statusCode: 200, httpVersion: nil, headerFields: nil)
             return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
@@ -206,6 +484,7 @@ class TargetDisplayedLocationsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "notifications",
                 "environmentId",
             ]))

--- a/AEPTarget/Tests/FunctionalTests/TargetFunctionalTestsBase.swift
+++ b/AEPTarget/Tests/FunctionalTests/TargetFunctionalTestsBase.swift
@@ -31,7 +31,7 @@ class TargetFunctionalTestsBase: XCTestCase {
 
     override func setUp() {
         // Mock data
-        mockConfigSharedState = ["target.clientCode": "acopprod3", "global.privacy": "optedin", "target.previewEnabled": true]
+        mockConfigSharedState = ["target.clientCode": "acopprod3", "global.privacy": "optedin", "target.previewEnabled": true, "target.propertyToken": "67444eb4-3681-40b4-831d-e082f5ccddcd"]
         mockLifecycleData = [
             "lifecyclecontextdata":
                 [

--- a/AEPTarget/Tests/FunctionalTests/TargetLoadRequestsFunctionalTests.swift
+++ b/AEPTarget/Tests/FunctionalTests/TargetLoadRequestsFunctionalTests.swift
@@ -93,6 +93,7 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "execute",
                 "environmentId",
             ]))
@@ -126,6 +127,14 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
                 "timeOffsetInMinutes",
             ]))
 
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("67444eb4-3681-40b4-831d-e082f5ccddcd", propertyDictionary["token"] as? String)
+            
+            // verifies payloadDictionary["execute"]
             guard let executeDictionary = payloadDictionary["execute"] as? [String: Any] else {
                 XCTFail()
                 return nil
@@ -223,6 +232,7 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "execute",
                 "environmentId",
             ]))
@@ -333,6 +343,7 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "execute",
                 "environmentId",
             ]))
@@ -449,6 +460,7 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
                 "id",
                 "experienceCloud",
                 "context",
+                "property",
                 "execute",
                 "environmentId",
             ]))
@@ -526,6 +538,312 @@ class TargetLoadRequestsFunctionalTests: TargetFunctionalTestsBase {
         XCTAssertTrue(target.readyForEvent(loadRequestEvent))
         // handles the prefetch event
         eventListener(loadRequestEvent)
+    }
+
+    func testLoadRequestContent_withPropertyTokenInEventData() {
+        mockConfigSharedState = ["target.clientCode": "acopprod3", "global.privacy": "optedin"]
+
+        // mocked network response
+        let responseString = """
+            {
+              "status": 200,
+              "id": {
+                "tntId": "DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0",
+                "marketingCloudVisitorId": "38209274908399841237725561727471528301"
+              },
+              "requestId": "01d4a408-6978-48f7-95c6-03f04160b257",
+              "client": "acopprod3",
+              "edgeHost": "mboxedge35.tt.omtrdc.net",
+              "execute": {
+                "mboxes": [
+                  {
+                    "index": 0,
+                    "name": "t_test_01",
+                    "options": [
+                      {
+                        "content": {
+                          "key1": "value1"
+                        },
+                        "type": "json"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+        """
+
+        let requestDataArray: [[String: Any]?] = [
+            TargetRequest(mboxName: "t_test_01", defaultContent: "default", targetParameters: TargetParameters(parameters: ["mbox-parameter-key1": "mbox-parameter-value1"]), contentCallback: nil)
+        ].map {
+            $0.asDictionary()
+        }
+
+        let data: [String: Any] = [
+            "request": requestDataArray,
+            "targetparams": TargetParameters(profileParameters: mockProfileParam).asDictionary() as Any,
+            "at_property": "a2ec61d0-fab8-42f9-bf0f-699d169b48d8"
+        ]
+        let loadRequestEvent = Event(name: "TargetLoadRequest", type: "com.adobe.eventType.target", source: "com.adobe.eventSource.requestContent", data: data)
+
+        // creates a configuration shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.configuration", event: loadRequestEvent, data: (value: mockConfigSharedState, status: .set))
+
+        // creates an identity shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.identity", event: loadRequestEvent, data: (value: mockIdentityData, status: .set))
+
+        // registers the event listeners for Target extension
+        target.onRegistered()
+
+        // override network service
+        let mockNetworkService = TestableNetworkService()
+        ServiceProvider.shared.networkService = mockNetworkService
+        mockNetworkService.mock { request in
+            // verifies network request
+            XCTAssertNotNil(request)
+            guard let payloadDictionary = self.payloadAsDictionary(request.connectPayload) else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId="))
+            XCTAssertTrue(Set(payloadDictionary.keys) == Set([
+                "id",
+                "experienceCloud",
+                "context",
+                "property",
+                "execute",
+                "environmentId",
+            ]))
+
+            // verifies payloadDictionary["id"]
+            guard let idDictionary = payloadDictionary["id"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("38209274908399841237725561727471528301", idDictionary["marketingCloudVisitorId"] as? String)
+            guard let vids = idDictionary["customerIds"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, vids.count)
+            XCTAssertEqual("unknown", vids[0]["authenticatedState"] as? String)
+            XCTAssertEqual("vid_id_1", vids[0]["id"] as? String)
+            XCTAssertEqual("vid_type_1", vids[0]["integrationCode"] as? String)
+
+            // verifies payloadDictionary["context"]
+            guard let context = payloadDictionary["context"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(Set(context.keys) == Set([
+                "userAgent",
+                "mobilePlatform",
+                "screen",
+                "channel",
+                "application",
+                "timeOffsetInMinutes",
+            ]))
+
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("a2ec61d0-fab8-42f9-bf0f-699d169b48d8", propertyDictionary["token"] as? String)
+            
+            // verifies payloadDictionary["execute"]
+            guard let executeDictionary = payloadDictionary["execute"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+
+            XCTAssertTrue(Set(executeDictionary.keys) == Set([
+                "mboxes",
+            ]))
+            guard let mboxes = executeDictionary["mboxes"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, mboxes.count)
+            let executeJson = JSON(parseJSON: self.prettify(executeDictionary))
+            XCTAssertEqual(executeJson["mboxes"][0]["index"].intValue, 0)
+            XCTAssertEqual(executeJson["mboxes"][0]["name"].stringValue, "t_test_01")
+            XCTAssertEqual(1, executeJson["mboxes"][0]["profileParameters"].count)
+            XCTAssertEqual(executeJson["mboxes"][0]["profileParameters"]["name"].stringValue, "Smith")
+            XCTAssertEqual(1, executeJson["mboxes"][0]["parameters"].count)
+            XCTAssertEqual(executeJson["mboxes"][0]["parameters"]["mbox-parameter-key1"].stringValue, "mbox-parameter-value1")
+            let validResponse = HTTPURLResponse(url: URL(string: "https://acopprod3.tt.omtrdc.net/rest/v1/delivery")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
+        }
+        guard let eventListener: EventListener = mockRuntime.listeners["com.adobe.eventType.target-com.adobe.eventSource.requestContent"] else {
+            XCTFail()
+            return
+        }
+        XCTAssertTrue(target.readyForEvent(loadRequestEvent))
+        // handles the load request event
+        eventListener(loadRequestEvent)
+
+        // verifies the content of network response was stored correctly
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", target.targetState.tntId)
+        XCTAssertEqual("mboxedge35.tt.omtrdc.net", target.targetState.edgeHost)
+        XCTAssertEqual(1, target.targetState.loadedMboxJsonDicts.count)
+        let mboxJson = prettify(target.targetState.loadedMboxJsonDicts["t_test_01"])
+        XCTAssertTrue(mboxJson.contains("\"name\" : \"t_test_01\""))
+
+        // verifies the Target's shared state
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", mockRuntime.createdSharedStates[0]?["tntid"] as? String)
+    }
+    
+    func testLoadRequestContent_withPropertyTokenInConfigurationAndEventData() {
+        // mocked network response
+        let responseString = """
+            {
+              "status": 200,
+              "id": {
+                "tntId": "DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0",
+                "marketingCloudVisitorId": "38209274908399841237725561727471528301"
+              },
+              "requestId": "01d4a408-6978-48f7-95c6-03f04160b257",
+              "client": "acopprod3",
+              "edgeHost": "mboxedge35.tt.omtrdc.net",
+              "execute": {
+                "mboxes": [
+                  {
+                    "index": 0,
+                    "name": "t_test_01",
+                    "options": [
+                      {
+                        "content": {
+                          "key1": "value1"
+                        },
+                        "type": "json"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+        """
+
+        let requestDataArray: [[String: Any]?] = [
+            TargetRequest(mboxName: "t_test_01", defaultContent: "default", targetParameters: TargetParameters(parameters: ["mbox-parameter-key1": "mbox-parameter-value1"]), contentCallback: nil)
+        ].map {
+            $0.asDictionary()
+        }
+
+        let data: [String: Any] = [
+            "request": requestDataArray,
+            "targetparams": TargetParameters(profileParameters: mockProfileParam).asDictionary() as Any,
+            "at_property": "a2ec61d0-fab8-42f9-bf0f-699d169b48d8"
+        ]
+        let loadRequestEvent = Event(name: "request", type: "com.adobe.eventType.target", source: "com.adobe.eventSource.requestContent", data: data)
+
+        // creates a configuration's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.configuration", event: loadRequestEvent, data: (value: mockConfigSharedState, status: .set))
+
+        // creates an identity's shared state
+        mockRuntime.simulateSharedState(extensionName: "com.adobe.module.identity", event: loadRequestEvent, data: (value: mockIdentityData, status: .set))
+
+        // registers the event listeners for Target extension
+        target.onRegistered()
+
+        // override network service
+        let mockNetworkService = TestableNetworkService()
+        ServiceProvider.shared.networkService = mockNetworkService
+        mockNetworkService.mock { request in
+            // verifies network request
+            XCTAssertNotNil(request)
+            guard let payloadDictionary = self.payloadAsDictionary(request.connectPayload) else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId="))
+            XCTAssertTrue(Set(payloadDictionary.keys) == Set([
+                "id",
+                "experienceCloud",
+                "context",
+                "property",
+                "execute",
+                "environmentId",
+            ]))
+
+            // verifies payloadDictionary["id"]
+            guard let idDictionary = payloadDictionary["id"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("38209274908399841237725561727471528301", idDictionary["marketingCloudVisitorId"] as? String)
+            guard let vids = idDictionary["customerIds"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, vids.count)
+            XCTAssertEqual("unknown", vids[0]["authenticatedState"] as? String)
+            XCTAssertEqual("vid_id_1", vids[0]["id"] as? String)
+            XCTAssertEqual("vid_type_1", vids[0]["integrationCode"] as? String)
+
+            // verifies payloadDictionary["context"]
+            guard let context = payloadDictionary["context"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertTrue(Set(context.keys) == Set([
+                "userAgent",
+                "mobilePlatform",
+                "screen",
+                "channel",
+                "application",
+                "timeOffsetInMinutes",
+            ]))
+
+            // verifies payloadDictionary["property"]
+            guard let propertyDictionary = payloadDictionary["property"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual("67444eb4-3681-40b4-831d-e082f5ccddcd", propertyDictionary["token"] as? String)
+            
+            // verifies payloadDictionary["execute"]
+            guard let executeDictionary = payloadDictionary["execute"] as? [String: Any] else {
+                XCTFail()
+                return nil
+            }
+
+            XCTAssertTrue(Set(executeDictionary.keys) == Set([
+                "mboxes",
+            ]))
+            guard let mboxes = executeDictionary["mboxes"] as? [[String: Any]] else {
+                XCTFail()
+                return nil
+            }
+            XCTAssertEqual(1, mboxes.count)
+            let executeJson = JSON(parseJSON: self.prettify(executeDictionary))
+            XCTAssertEqual(executeJson["mboxes"][0]["index"].intValue, 0)
+            XCTAssertEqual(executeJson["mboxes"][0]["name"].stringValue, "t_test_01")
+            XCTAssertEqual(executeJson["mboxes"][0]["profileParameters"]["name"].stringValue, "Smith")
+            XCTAssertEqual(executeJson["mboxes"][0]["parameters"]["mbox-parameter-key1"].stringValue, "mbox-parameter-value1")
+            let validResponse = HTTPURLResponse(url: URL(string: "https://acopprod3.tt.omtrdc.net/rest/v1/delivery")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
+        }
+        guard let eventListener: EventListener = mockRuntime.listeners["com.adobe.eventType.target-com.adobe.eventSource.requestContent"] else {
+            XCTFail()
+            return
+        }
+        XCTAssertTrue(target.readyForEvent(loadRequestEvent))
+        // handles the load request event
+        eventListener(loadRequestEvent)
+
+        // verifies the content of network response was stored correctly
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", target.targetState.tntId)
+        XCTAssertEqual("mboxedge35.tt.omtrdc.net", target.targetState.edgeHost)
+        XCTAssertEqual(1, target.targetState.loadedMboxJsonDicts.count)
+        let mboxJson = prettify(target.targetState.loadedMboxJsonDicts["t_test_01"])
+        XCTAssertTrue(mboxJson.contains("\"name\" : \"t_test_01\""))
+
+        // verifies the Target's shared state
+        XCTAssertEqual(1, mockRuntime.createdSharedStates.count)
+        XCTAssertEqual("DE03D4AD-1FFE-421F-B2F2-303BF26822C1.35_0", mockRuntime.createdSharedStates[0]?["tntid"] as? String)
     }
 
     func testLoadRequestContent_empty_requests() {

--- a/AEPTarget/Tests/UnitTests/Event+TargetTests.swift
+++ b/AEPTarget/Tests/UnitTests/Event+TargetTests.swift
@@ -72,6 +72,13 @@ class TargetEventTests: XCTestCase {
         XCTAssertEqual("20", parameters.profileParameters?["age"])
         XCTAssertEqual("order_1", parameters.order?.orderId)
     }
+    
+    func testTargetAtProperty() throws {
+        let requestDict = TargetRequest(mboxName: "request_1", defaultContent: mockDefaultContent_1, targetParameters: mockTargetParameter_1, contentCallback: nil).asDictionary()
+        let eventData = ["request": [requestDict], "at_property": "ccc8cdb3-c67a-6126-10b3-65d7f4d32b69"] as [String: Any]
+        let event = Event(name: "request", type: "com.adobe.eventType.target", source: "com.adobe.eventSource.requestContent", data: eventData as [String: Any])
+        XCTAssertEqual("ccc8cdb3-c67a-6126-10b3-65d7f4d32b69", event.propertyToken)
+    }
 
     func testIsLocationDisplayedEvent() throws {
         let eventData = [TargetConstants.EventDataKeys.TARGET_PARAMETERS: nil, TargetConstants.EventDataKeys.IS_LOCATION_DISPLAYED: true] as [String: Any?]

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,17 +5,17 @@ PODS:
   - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.7.0):
+  - AEPCore (3.7.1):
     - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.7.0)
-  - AEPIdentity (3.7.0):
-    - AEPCore (>= 3.7.0)
-  - AEPLifecycle (3.7.0):
-    - AEPCore (>= 3.7.0)
+    - AEPServices (>= 3.7.1)
+  - AEPIdentity (3.7.1):
+    - AEPCore (>= 3.7.1)
+  - AEPLifecycle (3.7.1):
+    - AEPCore (>= 3.7.1)
   - AEPRulesEngine (1.2.0)
-  - AEPServices (3.7.0)
-  - AEPSignal (3.7.0):
-    - AEPCore (>= 3.7.0)
+  - AEPServices (3.7.1)
+  - AEPSignal (3.7.1):
+    - AEPCore (>= 3.7.1)
   - SwiftLint (0.44.0)
   - SwiftyJSON (4.3.0)
 
@@ -45,12 +45,12 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AEPAnalytics: b83efee29b4323537cbce4b8f146d26cee6cdc80
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
-  AEPCore: 290dd609f261efe7a049bd3bdcbbc0734fe0e1fc
-  AEPIdentity: 965c831d132eba4874566220598590399f7617ac
-  AEPLifecycle: 7c2ba7de3b067999eb8b6a66f85f5815e87a06dc
+  AEPCore: 412fe933382892ab6c6af958d2f69ebcbca11216
+  AEPIdentity: 7cd5a51d8012aeaeee769e99597db016ad68b0d1
+  AEPLifecycle: 94c36a54f7e5466c5274bc822c53eaa410b74888
   AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
-  AEPServices: 7bc2af2a153ea223e87ec50c8e3fd6e0282869c6
-  AEPSignal: a7fbfd170fc121a4c0c413b6af644513d9966fde
+  AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
+  AEPSignal: c9b3c239120190fae8e8479d584d54b60af37d99
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Support remote property token updates with attach data rule:
The property token "at_property" can be provided in the JSON data to be attached to Target events (prefetch, execute, locations displayed or location clicked). Also, added the logic to remove any property tokens passed in mbox parameters (supported with Target iOS 2.x SDK).

The order or precedence will be as follows:
Property token configured in the extension card > Property token passed in Event Data

Note: Do not configure the property token in Target extension card on Data Collection UI if you wish to update it with attach data rule.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
