### PR TITLE
Enable Target preview by default if not enabled via configuration

### DIFF
--- a/AEPTarget.podspec
+++ b/AEPTarget.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPTarget"
-  s.version          = "3.3.0"
+  s.version          = "3.3.1"
   s.summary          = "Experience Platform Target extension for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
   s.description      = <<-DESC
                         The Experience Platform Target extension provides APIs that allow use of the Target product in the Adobe Experience Platform SDK.

--- a/AEPTarget.xcodeproj/project.pbxproj
+++ b/AEPTarget.xcodeproj/project.pbxproj
@@ -1174,7 +1174,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 3.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.target;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1206,7 +1206,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.3.0;
+				MARKETING_VERSION = 3.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.target;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AEPTarget/Sources/Target.swift
+++ b/AEPTarget/Sources/Target.swift
@@ -163,7 +163,8 @@ public class Target: NSObject, Extension {
             return
         }
 
-        guard let isPreviewEnabled = configSharedState[TargetConstants.Configuration.SharedState.Keys.TARGET_PREVIEW_ENABLED] as? Bool, isPreviewEnabled else {
+        let isPreviewEnabled = configSharedState[TargetConstants.Configuration.SharedState.Keys.TARGET_PREVIEW_ENABLED] as? Bool ?? true
+        if !isPreviewEnabled {
             Log.error(label: Target.LOG_TAG, "Target preview is disabled, please change the configuration and try again.")
             return
         }

--- a/AEPTarget/Sources/TargetConstants.swift
+++ b/AEPTarget/Sources/TargetConstants.swift
@@ -15,7 +15,7 @@ import Foundation
 enum TargetConstants {
     static let EXTENSION_NAME = "com.adobe.module.target"
     static let FRIENDLY_NAME = "Target"
-    static let EXTENSION_VERSION = "3.3.0"
+    static let EXTENSION_VERSION = "3.3.1"
     static let DATASTORE_NAME = EXTENSION_NAME
     static let DEFAULT_SESSION_TIMEOUT: Int = 30 * 60 // 30 mins
     static let DELIVERY_API_URL_BASE = "https://%@/rest/v1/delivery/?client=%@&sessionId=%@"

--- a/AEPTargetDemoApp/AppDelegate.swift
+++ b/AEPTargetDemoApp/AppDelegate.swift
@@ -27,7 +27,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         MobileCore.setLogLevel(.trace)
         MobileCore.registerExtensions([Lifecycle.self, Identity.self, Target.self, Signal.self, Analytics.self, Assurance.self])
         MobileCore.configureWith(appId: TestConstants.LAUNCH_ID)
-        MobileCore.updateConfigurationWith(configDict: ["target.previewEnabled": true])
 
         return true
     }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,17 +5,17 @@ PODS:
   - AEPAssurance (3.0.1):
     - AEPCore (>= 3.1.0)
     - AEPServices (>= 3.1.0)
-  - AEPCore (3.7.1):
+  - AEPCore (3.7.4):
     - AEPRulesEngine (>= 1.1.0)
-    - AEPServices (>= 3.7.1)
-  - AEPIdentity (3.7.1):
-    - AEPCore (>= 3.7.1)
-  - AEPLifecycle (3.7.1):
-    - AEPCore (>= 3.7.1)
+    - AEPServices (>= 3.7.4)
+  - AEPIdentity (3.7.4):
+    - AEPCore (>= 3.7.4)
+  - AEPLifecycle (3.7.4):
+    - AEPCore (>= 3.7.4)
   - AEPRulesEngine (1.2.0)
-  - AEPServices (3.7.1)
-  - AEPSignal (3.7.1):
-    - AEPCore (>= 3.7.1)
+  - AEPServices (3.7.4)
+  - AEPSignal (3.7.4):
+    - AEPCore (>= 3.7.4)
   - SwiftLint (0.44.0)
   - SwiftyJSON (4.3.0)
 
@@ -45,12 +45,12 @@ SPEC REPOS:
 SPEC CHECKSUMS:
   AEPAnalytics: b83efee29b4323537cbce4b8f146d26cee6cdc80
   AEPAssurance: b25880cd4b14f22c61a1dce19807bd0ca0fe9b17
-  AEPCore: 412fe933382892ab6c6af958d2f69ebcbca11216
-  AEPIdentity: 7cd5a51d8012aeaeee769e99597db016ad68b0d1
-  AEPLifecycle: 94c36a54f7e5466c5274bc822c53eaa410b74888
+  AEPCore: 4f2d6af62f492e87a6cc9cbf4c89ae6f0ea89d81
+  AEPIdentity: 4e298be480b327dd1fbb89e74210001bbbbb1c81
+  AEPLifecycle: 64107400233d9add603a87d2a4b36002bccb0129
   AEPRulesEngine: 71228dfdac24c9ded09be13e3257a7eb22468ccc
-  AEPServices: 7284c30359c789cd16bf366b4ea81094a66d21ab
-  AEPSignal: c9b3c239120190fae8e8479d584d54b60af37d99
+  AEPServices: 1c66ce125f9b3bbd46e42687b6929cd584bffdf4
+  AEPSignal: d6473de3410183f1f0754b92b2938a571332362e
   SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
   SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Alternatively, if your project has a `Package.swift` file, you can add AEPTarget
 
 ```
 dependencies: [
-    .package(url: "https://github.com/adobe/aepsdk-target-ios.git", .upToNextMajor(from: "3.3.0")),
+    .package(url: "https://github.com/adobe/aepsdk-target-ios.git", .upToNextMajor(from: "3.3.1")),
 ],
 targets: [
     .target(name: "YourTarget",


### PR DESCRIPTION
## Description

Ref: [MOB-18241]

If not specified programmatically, assume `target.previewEnabled` to be true (by default).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
