### PR TITLE
Added support for X-EXC-SDK & X-EXC-SDK-Version headers

### DIFF
--- a/AEPTarget.xcodeproj/project.pbxproj
+++ b/AEPTarget.xcodeproj/project.pbxproj
@@ -1174,7 +1174,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.target;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1205,7 +1205,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.0.1;
+				MARKETING_VERSION = 4.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.aep.target;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/AEPTarget/Sources/Target.swift
+++ b/AEPTarget/Sources/Target.swift
@@ -576,9 +576,8 @@ public class Target: NSObject, Extension {
 
         let coreVersion = eventHubData[TargetConstants.EventHub.SharedState.Keys.VERSION] as? String ?? "unknown"
 
-        // sdkVersion is a combination of Core+Target SDK version
-        let sdkVersion = "\(coreVersion)+\(TargetConstants.EXTENSION_VERSION)"
-        return sdkVersion
+        // sdkVersion is a combination of Mobile Core+Target SDK version
+        return "\(coreVersion)+\(TargetConstants.EXTENSION_VERSION)"
     }
 
     /// Prepares for the target requests and checks whether a target request can be sent.

--- a/AEPTarget/Sources/Target.swift
+++ b/AEPTarget/Sources/Target.swift
@@ -569,6 +569,18 @@ public class Target: NSObject, Extension {
         return String(format: TargetConstants.DELIVERY_API_URL_BASE, String(format: TargetConstants.API_URL_HOST_BASE, clientCode), clientCode, targetState.sessionId)
     }
 
+    private func getSdkVersion(eventHubData: [String: Any]?) -> String {
+        guard let eventHubData = eventHubData else {
+            return ""
+        }
+
+        let coreVersion = eventHubData[TargetConstants.EventHub.SharedState.Keys.VERSION] as? String ?? "unknown"
+
+        // sdkVersion is a combination of Core+Target SDK version
+        let sdkVersion = "\(coreVersion)+\(TargetConstants.EXTENSION_VERSION)"
+        return sdkVersion
+    }
+
     /// Prepares for the target requests and checks whether a target request can be sent.
     /// - returns: error indicating why the request can't be sent, nil otherwise
     private func prepareForTargetRequest() -> String? {
@@ -667,8 +679,6 @@ public class Target: NSObject, Extension {
             return "Failed to generate request parameter(JSON) for target delivery API call"
         }
 
-        let headers = [TargetConstants.HEADER_CONTENT_TYPE: TargetConstants.HEADER_CONTENT_TYPE_JSON]
-
         guard let clientCode = targetState.clientCode else {
             return "Missing client code"
         }
@@ -678,6 +688,11 @@ public class Target: NSObject, Extension {
         }
 
         let timeout = targetState.networkTimeout
+        let headers = [
+            TargetConstants.HEADER_CONTENT_TYPE: TargetConstants.HEADER_CONTENT_TYPE_JSON,
+            TargetConstants.HEADER_X_EXC_SDK: TargetConstants.HEADER_X_EXC_SDK_TARGET_MOBILE,
+            TargetConstants.HEADER_X_EXC_SDK_VERSION: getSdkVersion(eventHubData: getSharedState(extensionName: TargetConstants.EventHub.EXTENSION_NAME, event: event)?.value),
+        ]
 
         // https://developers.adobetarget.com/api/delivery-api/#tag/Delivery-API
         let request = NetworkRequest(url: url, httpMethod: .post, connectPayload: requestJson, httpHeaders: headers, connectTimeout: timeout, readTimeout: timeout)
@@ -904,7 +919,11 @@ public class Target: NSObject, Extension {
         }
 
         let timeout = targetState.networkTimeout
-        let headers = [TargetConstants.HEADER_CONTENT_TYPE: TargetConstants.HEADER_CONTENT_TYPE_JSON]
+        let headers = [
+            TargetConstants.HEADER_CONTENT_TYPE: TargetConstants.HEADER_CONTENT_TYPE_JSON,
+            TargetConstants.HEADER_X_EXC_SDK: TargetConstants.HEADER_X_EXC_SDK_TARGET_MOBILE,
+            TargetConstants.HEADER_X_EXC_SDK_VERSION: getSdkVersion(eventHubData: getSharedState(extensionName: TargetConstants.EventHub.EXTENSION_NAME, event: event)?.value),
+        ]
 
         // https://developers.adobetarget.com/api/delivery-api/#tag/Delivery-API
         let request = NetworkRequest(url: url, httpMethod: .post, connectPayload: requestJson, httpHeaders: headers, connectTimeout: timeout, readTimeout: timeout)

--- a/AEPTarget/Sources/TargetConstants.swift
+++ b/AEPTarget/Sources/TargetConstants.swift
@@ -15,14 +15,17 @@ import Foundation
 enum TargetConstants {
     static let EXTENSION_NAME = "com.adobe.module.target"
     static let FRIENDLY_NAME = "Target"
-    static let EXTENSION_VERSION = "4.0.1"
+    static let EXTENSION_VERSION = "4.0.2"
     static let DATASTORE_NAME = EXTENSION_NAME
     static let DEFAULT_SESSION_TIMEOUT: Int = 30 * 60 // 30 mins
     static let DELIVERY_API_URL_BASE = "https://%@/rest/v1/delivery/?client=%@&sessionId=%@"
     static let EDGE_HOST_BASE = "mboxedge%@"
     static let API_URL_HOST_BASE = "%@.tt.omtrdc.net"
     static let HEADER_CONTENT_TYPE = "Content-Type"
+    static let HEADER_X_EXC_SDK = "X-EXC-SDK"
+    static let HEADER_X_EXC_SDK_VERSION = "X-EXC-SDK-Version"
     static let HEADER_CONTENT_TYPE_JSON = "application/json"
+    static let HEADER_X_EXC_SDK_TARGET_MOBILE = "AdobeTargetMobile"
     static let A4T_ACTION_NAME = "AnalyticsForTarget"
 
     static let MAP_TO_CONTEXT_DATA_KEYS: [String: String] = [
@@ -231,6 +234,15 @@ enum TargetConstants {
             static let TRACK_INTERNAL = "trackinternal"
             static let TRACK_ACTION = "action"
             static let CONTEXT_DATA = "contextdata"
+        }
+    }
+
+    enum EventHub {
+        static let EXTENSION_NAME = "com.adobe.module.eventhub"
+        enum SharedState {
+            enum Keys {
+                static let VERSION = "version"
+            }
         }
     }
 

--- a/AEPTarget/Tests/IntegrationTests/TargetIntegrationTests.swift
+++ b/AEPTarget/Tests/IntegrationTests/TargetIntegrationTests.swift
@@ -185,6 +185,12 @@ class TargetIntegrationTests: XCTestCase {
         mockNetworkService.mock { request in
             Log.debug(label: self.T_LOG_TAG, "request url is: \(request.url.absoluteString)")
             if request.url.absoluteString.contains("https://amsdk.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+                
                 if let payloadDictionary = try? JSONSerialization.jsonObject(with: request.connectPayload, options: .allowFragments) as? [String: Any]
                 {
                     Log.debug(label: self.T_LOG_TAG, "request payload is: \n \(self.prettify(payloadDictionary))")
@@ -407,6 +413,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://amsdk.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
             }
             return nil
@@ -1093,6 +1105,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://amsdk.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 let connectPayloadString = String(decoding: request.connectPayload, as: UTF8.self)
                 if connectPayloadString.contains("ADCKKBC") {
                     targetRequestExpectation.fulfill()
@@ -1219,6 +1237,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://amsdk.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 let connectPayloadString = String(decoding: request.connectPayload, as: UTF8.self)
                 if connectPayloadString.contains("ADCKKBC") {
                     targetRequestExpectation.fulfill()
@@ -1662,6 +1686,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
             }
             return nil
@@ -1802,6 +1832,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
             }
             return nil
@@ -1954,6 +1990,12 @@ class TargetIntegrationTests: XCTestCase {
         ServiceProvider.shared.networkService = mockNetworkService
         mockNetworkService.mock { request in
             if request.url.absoluteString.contains("https://acopprod3.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 return (data: responseString.data(using: .utf8), response: validResponse, error: nil)
             }
 
@@ -2096,6 +2138,12 @@ class TargetIntegrationTests: XCTestCase {
             }
 
             if request.url.absoluteString.contains("https://mboxedge35.tt.omtrdc.net/rest/v1/delivery/?client=acopprod3&sessionId=") {
+                // verify request headers
+                let coreVersion = self.getLastValidSharedState("com.adobe.module.eventhub")?.value?["version"] ?? "unknown"
+                let requestHeaders: [String: String] = request.httpHeaders
+                XCTAssertEqual("AdobeTargetMobile", requestHeaders["X-EXC-SDK"])
+                XCTAssertEqual("\(coreVersion)+\(TargetTestConstants.EXTENSION_VERSION)", requestHeaders["X-EXC-SDK-Version"])
+
                 targetNotificationExpectation.fulfill()
                 return nil
             }

--- a/AEPTarget/Tests/TestHelpers/TargetTestConstants.swift
+++ b/AEPTarget/Tests/TestHelpers/TargetTestConstants.swift
@@ -11,6 +11,7 @@
  */
 
 enum TargetTestConstants {
+    static let EXTENSION_VERSION = "4.0.2"
     // preview parameters
     static let PREVIEW_MESSAGE_ID = "target-preview-message-id"
     static let PREVIEW_PARAMETERS = "at_preview_params"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added support for headers to determine SDK details in Target splunk logs

X-EXC-SDK - `AdobeTargetMobile`
X-EXC-SDK-Version - <Core+Target SDK version> e.g. `4.0.0+4.0.2`

- Updated Integration tests

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
